### PR TITLE
Use lowercase path when requiring plenary.path in utils.lua

### DIFF
--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -1,4 +1,4 @@
-local Path = require("plenary").Path
+local Path = require("plenary").path
 
 local log = require("lsp-file-operations.log")
 


### PR DESCRIPTION
I ran into the same issue as described in #7 with tsserver. After some investigation, I found that using lowercase `path` fixes the issue.

Closes #7 