### PR TITLE
feat: rucursive rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This is equivalent to:
 require("lsp-file-operations").setup {
   -- used to see debug logs in file `vim.fn.stdpath("cache") .. lsp-file-operations.log`
   debug = false
+  -- used to instruct the lsp to update all the files contained in a moved or renamed directory.
+  recursive_rename = false
 }
 ```
 

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -4,7 +4,8 @@ local will_rename = require('lsp-file-operations.will-rename')
 local log = require('lsp-file-operations.log')
 
 local default_config = {
-  debug = false
+  debug = false,
+  recurisive_rename = false,
 }
 
 M.setup = function(opts)
@@ -17,7 +18,9 @@ M.setup = function(opts)
   local ok_nvim_tree, nvim_tree_api = pcall(require, 'nvim-tree.api')
   if ok_nvim_tree then
     log.debug("Setting up nvim-tree integration")
-    nvim_tree_api.events.subscribe(nvim_tree_api.events.Event.WillRenameNode, will_rename.callback)
+    nvim_tree_api.events.subscribe(nvim_tree_api.events.Event.WillRenameNode, function(data)
+        will_rename.callback(opts, data)
+    end)
   end
 
   -- neo-tree integration
@@ -32,7 +35,7 @@ M.setup = function(opts)
         new_name = args.destination
       }
       log.debug("LSP rename data", vim.inspect(data))
-      will_rename.callback(data)
+      will_rename.callback(opts, data)
     end
 
     -- just in case setup is called multiple times

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -29,6 +29,7 @@ local get_absolute_path = function(name)
   local absolute_path = ensure_dir_trailing_slash(path:absolute(), is_dir)
   return absolute_path, is_dir
 end
+M.get_absolute_path = get_absolute_path
 
 local get_regex = function (pattern)
     local regex = vim.fn.glob2regpat(pattern.glob)

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -43,7 +43,7 @@ M.callback = function(opts, data)
           table.insert(files, { old_name = value, new_name = value:gsub(data.old_name, data.new_name) })
          end
       else
-        -- Not performing the recursive scan, lest just process the single file  
+        -- Not performing the recursive scan, lets just process the single file  
         table.insert(files, { old_name = data.old_name, new_name = data.new_name })
       end
 


### PR DESCRIPTION
This pull request (PR) extends the plugin logic to handle cases where a user moves or renames a directory, causing files dependent on the moved directory's contents to become outdated. For example, if we have a Node.js project structured as follows:

```
- lib
  - Lib1
    * index.js
  - Lib2
    * index.js
- index.js
```

Assuming that `index.js` imports `Lib1` and `Lib2`, and a user renames the directory `lib\Lib1` to `lib\MyLib1`, the import statement inside `index.js` is not automatically updated.

With this PR, the plugin will now search for all files within the affected directories, as well as any directories contained within them. It will then collect a list of these files and send instructions to the LSP to update all files that depend on the retrieved files.