### PR TITLE
fix: increase default timeout to 10 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ This is equivalent to:
 ```lua
 require("lsp-file-operations").setup {
   -- used to see debug logs in file `vim.fn.stdpath("cache") .. lsp-file-operations.log`
-  debug = false
+  debug = false,
+  -- how long to wait for file rename information before cancelling
+  timeout = 10000,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ This is equivalent to:
 require("lsp-file-operations").setup {
   -- used to see debug logs in file `vim.fn.stdpath("cache") .. lsp-file-operations.log`
   debug = false,
-  -- how long to wait for file rename information before cancelling
-  timeout = 10000,
+  -- how long to wait (in milliseconds) for file rename information before cancelling
+  timeout_ms = 10000,
 }
 ```
 

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -5,7 +5,7 @@ local log = require('lsp-file-operations.log')
 
 local default_config = {
   debug = false,
-  timeout = 10000,
+  timeout_ms = 10000,
 }
 
 M.setup = function(opts)

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -4,12 +4,13 @@ local will_rename = require('lsp-file-operations.will-rename')
 local log = require('lsp-file-operations.log')
 
 local default_config = {
-  debug = false
+  debug = false,
+  timeout = 10000,
 }
 
 M.setup = function(opts)
-  opts = vim.tbl_deep_extend("force", default_config, opts or {})
-  if opts.debug then
+  M.config = vim.tbl_deep_extend("force", default_config, opts or {})
+  if M.config.debug then
     log.level = "debug"
   end
 

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -15,8 +15,17 @@ local function getWorkspaceEdit(client, old_name, new_name)
   }
   log.debug("Sending workspace/willRenameFiles request", will_rename_params)
   -- TODO get timeout from config
-  local resp = client.request_sync("workspace/willRenameFiles", will_rename_params, 1000)
+  local timeout = require("lsp-file-operations").config.timeout
+  local success, resp = pcall(client.request_sync, "workspace/willRenameFiles", will_rename_params, timeout)
   log.debug("Got workspace/willRenameFiles response", resp)
+  if not success then
+    log.error("Error while sending workspace/willRenameFiles request", resp)
+    return nil
+  end
+  if resp == nil or resp.result == nil then
+    log.warn("Got empty workspace/willRenameFiles response, maybe a timeout?")
+    return nil
+  end
   return resp.result
 end
 

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -14,9 +14,8 @@ local function getWorkspaceEdit(client, old_name, new_name)
     }
   }
   log.debug("Sending workspace/willRenameFiles request", will_rename_params)
-  -- TODO get timeout from config
-  local timeout = require("lsp-file-operations").config.timeout
-  local success, resp = pcall(client.request_sync, "workspace/willRenameFiles", will_rename_params, timeout)
+  local timeout_ms = require("lsp-file-operations").config.timeout_ms
+  local success, resp = pcall(client.request_sync, "workspace/willRenameFiles", will_rename_params, timeout_ms)
   log.debug("Got workspace/willRenameFiles response", resp)
   if not success then
     log.error("Error while sending workspace/willRenameFiles request", resp)


### PR DESCRIPTION
fixes #16

The problem with https://github.com/pmizio/typescript-tools.nvim seems to be that it just takes a little longer for some reason. This attacks that problem from a few angles:

- It will use a pcall to detect an empty response and log a warning. An empty response without an error seems to be from timeouts.
- It makes timeout a config option
- It changes the default timout from 1 second to 10 seconds

10 seconds as the new default is pretty arbitrary. It works for me. 😄 

I do think that 1 second is really too short though. In my own config, I'll set this to 30 seconds.
