### PR TITLE
Fix URI on windows

### DIFF
--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -8,8 +8,8 @@ local function getWorkspaceEdit(client, old_name, new_name)
   local will_rename_params = {
     files = {
       {
-        oldUri = "file://" .. old_name,
-        newUri = "file://" .. new_name,
+        oldUri = vim.uri_from_fname(old_name),
+        newUri = vim.uri_from_fname(new_name),
       }
     }
   }


### PR DESCRIPTION
Closes #12.
Windows path uses `\` but URIs use `/`, so to solve this in the simplest way, I just used the built-in function for generating URI.