### PR TITLE
Add support for `didRenameFiles` file operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,47 +5,49 @@ support](https://neovim.io/doc/user/lsp.html).
 This plugin works by subscribing to events emitted by [nvim-tree](https://github.com/nvim-tree/nvim-tree.lua)
 and [neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim). But other integrations are possible.
 
-
 ## Features
-* [workspace/WillRename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles)
 
-WillRename requests supported in couple lsp-servers and allows to automagically apply some refactorings while you moving files around. Currently tested with [metals](https://scalameta.org/metals/), [rust-analyzer](https://rust-analyzer.github.io/) and [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
-
+- [workspace/WillRename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles): WillRename requests are supported in couple lsp-servers and allows to automagically apply some refactorings while you moving files around. Currently tested with [metals](https://scalameta.org/metals/), [rust-analyzer](https://rust-analyzer.github.io/) and [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
+- [workspace/DidRename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didRenameFiles): DidRename notifications are supported in couple lsp-servers and also can be used to automagically apply some refactorings while you moving files around. Currently tested with [vtsls](https://github.com/yioneko/vtsls) and [lua-language-server](https://github.com/LuaLS/lua-language-server)
 
 https://user-images.githubusercontent.com/14187674/211327507-39f21a74-0a43-43f0-ba3e-91109125286c.mp4
-
 
 **If you have usecases for any other operations please open an issue.**
 
 ## Installation
+
 ### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 #### For Nvim-tree Users
+
 ```lua
-use {
-  'antosha417/nvim-lsp-file-operations',
+use({
+  "antosha417/nvim-lsp-file-operations",
   requires = {
     "nvim-lua/plenary.nvim",
     "nvim-tree/nvim-tree.lua",
-  }
-}
+  },
+})
 ```
 
 #### For Neo-tree Users
+
 ```lua
-use {
-  'antosha417/nvim-lsp-file-operations',
+use({
+  "antosha417/nvim-lsp-file-operations",
   requires = {
     "nvim-lua/plenary.nvim",
     "nvim-neo-tree/neo-tree.nvim",
-  }
-}
+  },
+})
 ```
 
-### Using [lazy.nvim](https://github.com/folke/lazy.nvim) 
+### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+
 Note that the config function will let you skip the setup step.
 
 #### For Nvim-tree Users
+
 ```lua
 return {
   {
@@ -62,6 +64,7 @@ return {
 ```
 
 #### For Neo-tree Users
+
 ```lua
 return {
   {
@@ -82,19 +85,22 @@ nvim-lsp-file-operations for it to work, so nvim-lsp-file-operations depends on 
 around.
 
 ## Setup
+
 ```lua
 require("lsp-file-operations").setup()
 ```
+
 This is equivalent to:
+
 ```lua
-require("lsp-file-operations").setup {
+require("lsp-file-operations").setup({
   -- used to see debug logs in file `vim.fn.stdpath("cache") .. lsp-file-operations.log`
   debug = false,
   -- how long to wait (in milliseconds) for file rename information before cancelling
   timeout_ms = 10000,
-}
+})
 ```
 
 ## Contributing
-PRs are always welcome.
 
+PRs are always welcome.

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local will_rename = require("lsp-file-operations.will-rename")
-local did_rename = require("lsp-file-operations.did-rename")
 local log = require("lsp-file-operations.log")
 
 local default_config = {
@@ -19,8 +17,12 @@ M.setup = function(opts)
   local ok_nvim_tree, nvim_tree_api = pcall(require, "nvim-tree.api")
   if ok_nvim_tree then
     log.debug("Setting up nvim-tree integration")
-    nvim_tree_api.events.subscribe(nvim_tree_api.events.Event.WillRenameNode, will_rename.callback)
-    nvim_tree_api.events.subscribe(nvim_tree_api.events.Event.NodeRenamed, did_rename.callback)
+    nvim_tree_api.events.subscribe(nvim_tree_api.events.Event.WillRenameNode, function(data)
+      require("lsp-file-operations.will-rename").callback(data)
+    end)
+    nvim_tree_api.events.subscribe(nvim_tree_api.events.Event.NodeRenamed, function(data)
+      require("lsp-file-operations.did-rename").callback(data)
+    end)
   end
 
   -- neo-tree integration
@@ -35,7 +37,7 @@ M.setup = function(opts)
         new_name = args.destination,
       }
       log.debug("LSP will rename data", vim.inspect(data))
-      will_rename.callback(data)
+      require("lsp-file-operations.will-rename").callback(data)
     end
 
     local did_rename_callback = function(args)
@@ -44,7 +46,7 @@ M.setup = function(opts)
         new_name = args.destination,
       }
       log.debug("LSP did rename data", vim.inspect(data))
-      did_rename.callback(data)
+      require("lsp-file-operations.did-rename").callback(data)
     end
 
     -- just in case setup is called multiple times

--- a/lua/lsp-file-operations/did-rename.lua
+++ b/lua/lsp-file-operations/did-rename.lua
@@ -1,0 +1,25 @@
+local utils = require("lsp-file-operations.utils")
+local log = require("lsp-file-operations.log")
+
+local M = {}
+
+M.callback = function(data)
+  for _, client in pairs(vim.lsp.get_active_clients()) do
+    local did_rename =
+      utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "didRename" })
+    if did_rename ~= nil then
+      local filters = did_rename.filters or {}
+      if utils.matches_filters(filters, data.old_name) then
+        local params = {
+          files = {
+            { oldUri = vim.uri_from_fname(data.old_name), newUri = vim.uri_from_fname(data.new_name) },
+          },
+        }
+        client.notify("workspace/didRenameFiles", params)
+        log.debug("Sending workspace/didRenameFiles notification", params)
+      end
+    end
+  end
+end
+
+return M


### PR DESCRIPTION
This adds support for `didRenameFiles` notification which adds in support for more import updates for language servers like `lua-language-server`, `vstls`, and more!

This event is simply a notification, so there isn't any response or use of the timeout at all since the operation is already finished.

This also fixes the event for neo-tree for `willRenameFiles` to the events before the moving/renaming happens. Also a very minor performance improvement where we don't need to load the modules for the operations until they actually occur.