### PR TITLE
fix: Correct optionations typo

### DIFF
--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -16,12 +16,12 @@ local default_config = {
 }
 
 local modules = {
-  willRenameFiles = "lsp-file-optionations.will-rename",
-  didRenameFiles = "lsp-file-optionations.did-rename",
-  willCreateFiles = "lsp-file-optionations.will-create",
-  didCreateFiles = "lsp-file-optionations.did-create",
-  willDeleteFiles = "lsp-file-optionations.will-delete",
-  didDeleteFiles = "lsp-file-optionations.did-delete",
+  willRenameFiles = "lsp-file-operations.will-rename",
+  didRenameFiles = "lsp-file-operations.did-rename",
+  willCreateFiles = "lsp-file-operations.will-create",
+  didCreateFiles = "lsp-file-operations.did-create",
+  willDeleteFiles = "lsp-file-operations.will-delete",
+  didDeleteFiles = "lsp-file-operations.did-delete",
 }
 
 ---@alias HandlerMap table<string, string[]> a mapping from modules to events that trigger it


### PR DESCRIPTION
Currently, the local modules are set as:

```
local modules = {
  willRenameFiles = "lsp-file-optionations.will-rename",
  didRenameFiles = "lsp-file-optionations.did-rename",
  willCreateFiles = "lsp-file-optionations.will-create",
  didCreateFiles = "lsp-file-optionations.did-create",
  willDeleteFiles = "lsp-file-optionations.will-delete",
  didDeleteFiles = "lsp-file-optionations.did-delete",
}
```

Which is pointing to a filepath that doesn't exist. This causes the following errors on these events:

```
[NvimTree] Handler for event WillRemoveFile errored. "...azy/nvim-lsp-file-operations/lua/lsp-file-operations.lua:68: module 'lsp-file-optionations.will-delete' not found:\n\tno field package.preload['lsp-file-optionations.will-delete']\ncache_loader: module lsp-file-optionations.will-delete not found\ncache_loader_lib: module lsp-file-optionations.will-delete not found\n\tno file './lsp-file-optionations/will-delete.lua'\n\tno file '/__w/neovim/neovim/.deps/usr/share/luajit-2.1/lsp-file-optionations/will-delete.lua'\n\tno file '/usr/local/share/lua/5.1/lsp-file-optionations/will-delete.lua'\n\tno file '/usr/local/share/lua/5.1/lsp-file-optionations/will-delete/init.lua'\n\tno file '/__w/neovim/neovim/.deps/usr/share/lua/5.1/lsp-file-optionations/will-delete.lua'\n\tno file '/__w/neovim/neovim/.deps/usr/share/lua/5.1/lsp-file-optionations/will-delete/init.lua'\n\tno file './lsp-file-optionations/will-delete.so'\n\tno file '/usr/local/lib/lua/5.1/lsp-file-optionations/will-delete.so'\n\tno file '/__w/neovim/neovim/.deps/usr/lib/lua/5.1/lsp-file-optionations/will-delete.so'\n\tno file '/usr/local/lib/lua/5.1/loadall.so'\n\tno file './lsp-file-optionations.so'\n\tno file '/usr/local/lib/lua/5.1/lsp-file-optionations.so'\n\tno file '/__w/neovim/neovim/.deps/usr/lib/lua/5.1/lsp-file-optionations.so'\n\tno file '/usr/local/lib/lua/5.1/loadall.so'"
Press ENTER or type command to continue
```
This PR replaces the above typo from `optionations` to `operations`, and solves the issue.