### PR TITLE
refactor: use `vim.lsp.get_clients()`

### DIFF
--- a/lua/lsp-file-operations/did-create.lua
+++ b/lua/lsp-file-operations/did-create.lua
@@ -4,7 +4,7 @@ local log = require("lsp-file-operations.log")
 local M = {}
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  for _, client in pairs(vim.lsp.get_clients()) do
     local did_create =
       utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "didCreate" })
     if did_create ~= nil then

--- a/lua/lsp-file-operations/did-delete.lua
+++ b/lua/lsp-file-operations/did-delete.lua
@@ -4,7 +4,7 @@ local log = require("lsp-file-operations.log")
 local M = {}
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  for _, client in pairs(vim.lsp.get_clients()) do
     local did_delete =
       utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "didDelete" })
     if did_delete ~= nil then

--- a/lua/lsp-file-operations/did-rename.lua
+++ b/lua/lsp-file-operations/did-rename.lua
@@ -4,7 +4,7 @@ local log = require("lsp-file-operations.log")
 local M = {}
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  for _, client in pairs(vim.lsp.get_clients()) do
     local did_rename =
       utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "didRename" })
     if did_rename ~= nil then

--- a/lua/lsp-file-operations/will-create.lua
+++ b/lua/lsp-file-operations/will-create.lua
@@ -27,7 +27,7 @@ local function getWorkspaceEdit(client, fname)
 end
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  for _, client in pairs(vim.lsp.get_clients()) do
     local will_create =
       utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "willCreate" })
     if will_create ~= nil then

--- a/lua/lsp-file-operations/will-delete.lua
+++ b/lua/lsp-file-operations/will-delete.lua
@@ -27,7 +27,7 @@ local function getWorkspaceEdit(client, fname)
 end
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  for _, client in pairs(vim.lsp.get_clients()) do
     local will_delete =
       utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "willDelete" })
     if will_delete ~= nil then

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -28,7 +28,7 @@ local function getWorkspaceEdit(client, old_name, new_name)
 end
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  for _, client in pairs(vim.lsp.get_clients()) do
     local will_rename =
       utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "willRename" })
     if will_rename ~= nil then


### PR DESCRIPTION
Fixes #31 

I haven't checked, but this change should raise the minimum supported version to v0.10. If that's not desired, we can use a workaround to still support older versions