### PR TITLE
docs: add basedpyright to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin works by subscribing to events emitted by [nvim-tree](https://github
 
 Full implementation of all [`workspace.fileOperations`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/) in the current lsp spec:
 
-- [workspace/WillRename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles) (Currently tested with [metals](https://scalameta.org/metals/), [rust-analyzer](https://rust-analyzer.github.io/) and [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server))
+- [workspace/WillRename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles) (Currently tested with [metals](https://scalameta.org/metals/), [rust-analyzer](https://rust-analyzer.github.io/), [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server) and [basedpyright](https://docs.basedpyright.com/latest))
 - [workspace/DidRename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didRenameFiles) (Currently tested with [vtsls](https://github.com/yioneko/vtsls) and [lua-language-server](https://github.com/LuaLS/lua-language-server))
 - [workspace/WillCreate](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willCreateFiles)
 - [workspace/DidCreate](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didCreateFiles)


### PR DESCRIPTION
`basedpyright` has the following workspace capabilities:

```
  workspace = {
    fileOperations = {
      willRename = {
        filters = { {
            pattern = {
              glob = "**/*"
            }
          } }
      }
    },
    workspaceFolders = {
      changeNotifications = true,
      supported = true
    }
  },
```
I tested renaming a file with `nvim-tree` and all worked great!