### PR TITLE
feat: add new `BEFORE_FILE_{ADD/DELETE}` events to neo-tree integration

### DIFF
--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -79,10 +79,10 @@ M.setup = function(opts)
     local events = {
       willRenameFiles = { neo_tree_events.BEFORE_FILE_RENAME, neo_tree_events.BEFORE_FILE_MOVE },
       didRenameFiles = { neo_tree_events.FILE_RENAMED, neo_tree_events.FILE_MOVED },
+      willCreateFiles = { neo_tree_events.BEFORE_FILE_ADD },
       didCreateFiles = { neo_tree_events.FILE_ADDED },
+      willDeleteFiles = { neo_tree_events.BEFORE_FILE_DELETE },
       didDeleteFiles = { neo_tree_events.FILE_DELETED },
-      -- currently no events in neo-tree for before creating or deleting, so unable to support those file operations
-      -- Issue to add the missing events: https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1276
     }
     setup_events(events, function(module, event)
       -- create an event name based on the module and the event


### PR DESCRIPTION
My issue on Neo-tree to add the missing LSP file events was resolved so this adds support for those new events: https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1276

Currently these events are not in an officially stable release, but because of how the iteration works the function still works with old versions because the tables will resolve to `{ nil }` which will be treated the same as an empty table when iterating.