### PR TITLE
refactor: fix deprecations, StyLua formatting, functions normalized

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ lspconfig.util.default_config = vim.tbl_extend(
 ## Contributing
 
 PRs are always welcome.
+
+<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -1,35 +1,49 @@
 local log = require("lsp-file-operations.log")
 local utils = require("lsp-file-operations.utils")
 
+---@class LspFileOpsConfig.Operations
+---@field didCreateFiles? boolean
+---@field didDeleteFiles? boolean
+---@field didRenameFiles? boolean
+---@field willCreateFiles? boolean
+---@field willDeleteFiles? boolean
+---@field willRenameFiles? boolean
+
+---@class LspFileOpsConfig
+---@field debug? boolean
+---@field timeout_ms? integer
+---@field operations? LspFileOpsConfig.Operations
 local default_config = {
   debug = false,
   timeout_ms = 10000,
   operations = {
-    willRenameFiles = true,
+    didCreateFiles = true,
+    didDeleteFiles = true,
     didRenameFiles = true,
     willCreateFiles = true,
-    didCreateFiles = true,
     willDeleteFiles = true,
-    didDeleteFiles = true,
+    willRenameFiles = true,
   },
 }
 
+---@enum LspFileOpsModules
 local modules = {
-  willRenameFiles = "lsp-file-operations.will-rename",
+  didCreateFiles = "lsp-file-operations.did-create",
+  didDeleteFiles = "lsp-file-operations.did-delete",
   didRenameFiles = "lsp-file-operations.did-rename",
   willCreateFiles = "lsp-file-operations.will-create",
-  didCreateFiles = "lsp-file-operations.did-create",
   willDeleteFiles = "lsp-file-operations.will-delete",
-  didDeleteFiles = "lsp-file-operations.did-delete",
+  willRenameFiles = "lsp-file-operations.will-rename",
 }
 
+---@enum LspFileOpsCapabilities
 local capabilities = {
-  willRenameFiles = "willRename",
+  didCreateFiles = "didCreate",
+  didDeleteFiles = "didDelete",
   didRenameFiles = "didRename",
   willCreateFiles = "willCreate",
-  didCreateFiles = "didCreate",
   willDeleteFiles = "willDelete",
-  didDeleteFiles = "didDelete",
+  willRenameFiles = "willRename",
 }
 
 ---@alias HandlerMap table<string, string[]> a mapping from modules to events that trigger it
@@ -55,7 +69,7 @@ local function setup_events(op_events, subscribe)
   end
 end
 
----@param opts? table
+---@param opts? LspFileOpsConfig
 function M.setup(opts)
   utils.validate({ opts = { opts, { "table", "nil" }, true } })
 
@@ -136,14 +150,13 @@ function M.setup(opts)
   if pcall(require, "triptych") then
     log.debug("Setting up triptych integration")
 
-    ---@type HandlerMap
-    local events = {
-      willRenameFiles = { "TriptychWillMoveNode" },
+    local events = { ---@type HandlerMap
+      didCreateFiles = { "TriptychDidCreateNode" },
+      didDeleteFiles = { "TriptychDidDeleteNode" },
       didRenameFiles = { "TriptychDidMoveNode" },
       willCreateFiles = { "TriptychWillCreateNode" },
-      didCreateFiles = { "TriptychDidCreateNode" },
       willDeleteFiles = { "TriptychWillDeleteNode" },
-      didDeleteFiles = { "TriptychDidDeleteNode" },
+      willRenameFiles = { "TriptychWillMoveNode" },
     }
     setup_events(events, function(module, event)
       vim.api.nvim_create_autocmd("User", {
@@ -168,12 +181,7 @@ end
 ---@return lsp.ClientCapabilities capabilities
 function M.default_capabilities()
   local config = M.config or default_config
-  ---@type lsp.ClientCapabilities
-  local result = {
-    workspace = {
-      fileOperations = {},
-    },
-  }
+  local result = { workspace = { fileOperations = {} } } ---@type lsp.ClientCapabilities
   for operation, capability in pairs(capabilities) do
     result.workspace.fileOperations[capability] = config.operations[operation]
   end

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -46,13 +46,11 @@ local capabilities = {
   willRenameFiles = "willRename",
 }
 
----@alias HandlerMap table<string, string[]> a mapping from modules to events that trigger it
-
 ---@class LspFileOps
 local M = {}
 
 --- helper function to subscribe events to a given module callback
----@param op_events HandlerMap the table that maps modules to event strings
+---@param op_events table<string, string[]> the table that maps modules to event strings
 ---@param subscribe fun(module: string, event: string) the function for how to subscribe a module to an event
 local function setup_events(op_events, subscribe)
   utils.validate({
@@ -83,9 +81,8 @@ function M.setup(opts)
   if ok_nvim_tree then
     log.debug("Setting up nvim-tree integration")
 
-    ---@type HandlerMap
     local nvim_tree_event = nvim_tree_api.events.Event
-    local events = {
+    local events = { ---@type table<string, string[]>
       willRenameFiles = { nvim_tree_event.WillRenameNode },
       didRenameFiles = { nvim_tree_event.NodeRenamed },
       willCreateFiles = { nvim_tree_event.WillCreateFile },
@@ -105,8 +102,7 @@ function M.setup(opts)
   if ok_neo_tree then
     log.debug("Setting up neo-tree integration")
 
-    ---@type HandlerMap
-    local events = {
+    local events = { ---@type table<string, string[]>
       willRenameFiles = { neo_tree_events.BEFORE_FILE_RENAME, neo_tree_events.BEFORE_FILE_MOVE },
       didRenameFiles = { neo_tree_events.FILE_RENAMED, neo_tree_events.FILE_MOVED },
       didCreateFiles = { neo_tree_events.FILE_ADDED },
@@ -150,7 +146,7 @@ function M.setup(opts)
   if pcall(require, "triptych") then
     log.debug("Setting up triptych integration")
 
-    local events = { ---@type HandlerMap
+    local events = { ---@type table<string, string[]>
       didCreateFiles = { "TriptychDidCreateNode" },
       didDeleteFiles = { "TriptychDidDeleteNode" },
       didRenameFiles = { "TriptychDidMoveNode" },

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -1,6 +1,5 @@
-local M = {}
-
 local log = require("lsp-file-operations.log")
+local utils = require("lsp-file-operations.utils")
 
 local default_config = {
   debug = false,
@@ -35,10 +34,18 @@ local capabilities = {
 
 ---@alias HandlerMap table<string, string[]> a mapping from modules to events that trigger it
 
+---@class LspFileOps
+local M = {}
+
 --- helper function to subscribe events to a given module callback
 ---@param op_events HandlerMap the table that maps modules to event strings
 ---@param subscribe fun(module: string, event: string) the function for how to subscribe a module to an event
 local function setup_events(op_events, subscribe)
+  utils.validate({
+    op_events = { op_events, { "table" } },
+    subscribe = { subscribe, { "function" } },
+  })
+
   for operation, enabled in pairs(M.config.operations) do
     if enabled and modules[operation] and op_events[operation] then
       vim.tbl_map(function(event)
@@ -48,7 +55,10 @@ local function setup_events(op_events, subscribe)
   end
 end
 
+---@param opts? table
 function M.setup(opts)
+  utils.validate({ opts = { opts, { "table", "nil" }, true } })
+
   M.config = vim.tbl_deep_extend("force", default_config, opts or {})
   if M.config.debug then
     log.level = "debug"
@@ -155,8 +165,10 @@ end
 
 --- The extra client capabilities provided by this plugin. To be merged with
 --- vim.lsp.protocol.make_client_capabilities() and sent to the LSP server.
+---@return lsp.ClientCapabilities capabilities
 function M.default_capabilities()
   local config = M.config or default_config
+  ---@type lsp.ClientCapabilities
   local result = {
     workspace = {
       fileOperations = {},

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -40,13 +40,10 @@ local capabilities = {
 ---@param subscribe fun(module: string, event: string) the function for how to subscribe a module to an event
 local function setup_events(op_events, subscribe)
   for operation, enabled in pairs(M.config.operations) do
-    if enabled then
-      local module, events = modules[operation], op_events[operation]
-      if module and events then
-        vim.tbl_map(function(event)
-          subscribe(module, event)
-        end, events)
-      end
+    if enabled and modules[operation] and op_events[operation] then
+      vim.tbl_map(function(event)
+        subscribe(modules[operation], event)
+      end, op_events[operation])
     end
   end
 end
@@ -101,28 +98,24 @@ function M.setup(opts)
         id = id,
         event = event,
         handler = function(args)
-          -- translate neo-tree arguemnts to the same format as nvim-tree
-          if type(args) == "table" then
-            args = { old_name = args.source, new_name = args.destination }
-          else
-            args = { fname = args }
-          end
           -- load module and call the callback
-          require(module).callback(args)
+          require(module).callback(
+            -- translate neo-tree arguemnts to the same format as nvim-tree
+            type(args) == "table" and { old_name = args.source, new_name = args.destination }
+              or { fname = args }
+          )
         end,
       })
       neo_tree_events.subscribe({
         id = id,
         event = event,
         handler = function(args)
-          -- translate neo-tree arguemnts to the same format as nvim-tree
-          if type(args) == "table" then
-            args = { old_name = args.source, new_name = args.destination }
-          else
-            args = { fname = args }
-          end
           -- load module and call the callback
-          require(module).callback(args)
+          require(module).callback(
+            -- translate neo-tree arguemnts to the same format as nvim-tree
+            type(args) == "table" and { old_name = args.source, new_name = args.destination }
+              or { fname = args }
+          )
         end,
       })
     end)
@@ -130,8 +123,7 @@ function M.setup(opts)
   end
 
   -- triptych integration
-  local ok_triptych, _ = pcall(require, "triptych")
-  if ok_triptych then
+  if pcall(require, "triptych") then
     log.debug("Setting up triptych integration")
 
     ---@type HandlerMap
@@ -148,14 +140,12 @@ function M.setup(opts)
         group = "TriptychEvents",
         pattern = event,
         callback = function(callback_data)
-          local args = {}
           local data = callback_data.data
-          if data.from_path and data.to_path then
-            args = { old_name = data.from_path, new_name = data.to_path }
-          else
-            args = { fname = data.path }
-          end
-          require(module).callback(args)
+          require(module).callback(
+            (data.from_path and data.to_path)
+                and { old_name = data.from_path, new_name = data.to_path }
+              or { fname = data.path }
+          )
         end,
       })
     end)

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -169,3 +169,4 @@ function M.default_capabilities()
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations.lua
+++ b/lua/lsp-file-operations.lua
@@ -51,7 +51,7 @@ local function setup_events(op_events, subscribe)
   end
 end
 
-M.setup = function(opts)
+function M.setup(opts)
   M.config = vim.tbl_deep_extend("force", default_config, opts or {})
   if M.config.debug then
     log.level = "debug"
@@ -97,7 +97,20 @@ M.setup = function(opts)
       -- create an event name based on the module and the event
       local id = ("%s.%s"):format(module, event)
       -- just in case setup is called twice, unsubscribe from event
-      neo_tree_events.unsubscribe({ id = id })
+      neo_tree_events.unsubscribe({
+        id = id,
+        event = event,
+        handler = function(args)
+          -- translate neo-tree arguemnts to the same format as nvim-tree
+          if type(args) == "table" then
+            args = { old_name = args.source, new_name = args.destination }
+          else
+            args = { fname = args }
+          end
+          -- load module and call the callback
+          require(module).callback(args)
+        end,
+      })
       neo_tree_events.subscribe({
         id = id,
         event = event,
@@ -123,18 +136,18 @@ M.setup = function(opts)
 
     ---@type HandlerMap
     local events = {
-      willRenameFiles = { 'TriptychWillMoveNode' },
-      didRenameFiles = { 'TriptychDidMoveNode' },
-      willCreateFiles = { 'TriptychWillCreateNode' },
-      didCreateFiles = { 'TriptychDidCreateNode' },
-      willDeleteFiles = { 'TriptychWillDeleteNode' },
-      didDeleteFiles = { 'TriptychDidDeleteNode' },
+      willRenameFiles = { "TriptychWillMoveNode" },
+      didRenameFiles = { "TriptychDidMoveNode" },
+      willCreateFiles = { "TriptychWillCreateNode" },
+      didCreateFiles = { "TriptychDidCreateNode" },
+      willDeleteFiles = { "TriptychWillDeleteNode" },
+      didDeleteFiles = { "TriptychDidDeleteNode" },
     }
     setup_events(events, function(module, event)
-      vim.api.nvim_create_autocmd('User', {
-        group = 'TriptychEvents',
+      vim.api.nvim_create_autocmd("User", {
+        group = "TriptychEvents",
         pattern = event,
-        callback = function (callback_data)
+        callback = function(callback_data)
           local args = {}
           local data = callback_data.data
           if data.from_path and data.to_path then
@@ -152,12 +165,12 @@ end
 
 --- The extra client capabilities provided by this plugin. To be merged with
 --- vim.lsp.protocol.make_client_capabilities() and sent to the LSP server.
-M.default_capabilities = function()
+function M.default_capabilities()
   local config = M.config or default_config
   local result = {
     workspace = {
-      fileOperations = {}
-    }
+      fileOperations = {},
+    },
   }
   for operation, capability in pairs(capabilities) do
     result.workspace.fileOperations[capability] = config.operations[operation]

--- a/lua/lsp-file-operations/did-create.lua
+++ b/lua/lsp-file-operations/did-create.lua
@@ -1,9 +1,12 @@
 local utils = require("lsp-file-operations.utils")
 local log = require("lsp-file-operations.log")
 
+---@class LspFileOps.DidCreate
 local M = {}
 
 function M.callback(data)
+  utils.validate({ data = { data, { "table" } } })
+
   local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
     or vim.lsp.get_active_clients()
   for _, client in pairs(clients) do
@@ -12,21 +15,14 @@ function M.callback(data)
         client,
         { "server_capabilities", "workspace", "fileOperations", "didCreate" }
       )
-      if did_create then
-        local filters = did_create.filters or {}
-        if utils.matches_filters(filters, data.fname) then
-          local params = {
-            files = {
-              { uri = vim.uri_from_fname(data.fname) },
-            },
-          }
-          if vim.fn.has("nvim-0.11") == 1 then
-            client:notify("workspace/didCreateFiles", params)
-          else
-            client.notify("workspace/didCreateFiles", params)
-          end
-          log.debug("Sending workspace/didCreateFiles notification", params)
+      if did_create and utils.matches_filters(did_create.filters or {}, data.fname) then
+        local params = { files = { { uri = vim.uri_from_fname(data.fname) } } }
+        if vim.fn.has("nvim-0.11") == 1 then
+          client:notify("workspace/didCreateFiles", params)
+        else
+          client.notify("workspace/didCreateFiles", params)
         end
+        log.debug("Sending workspace/didCreateFiles notification", params)
       end
     end
   end

--- a/lua/lsp-file-operations/did-create.lua
+++ b/lua/lsp-file-operations/did-create.lua
@@ -3,20 +3,30 @@ local log = require("lsp-file-operations.log")
 
 local M = {}
 
-M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
-    local did_create =
-      utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "didCreate" })
-    if did_create ~= nil then
-      local filters = did_create.filters or {}
-      if utils.matches_filters(filters, data.fname) then
-        local params = {
-          files = {
-            { uri = vim.uri_from_fname(data.fname) },
-          },
-        }
-        client.notify("workspace/didCreateFiles", params)
-        log.debug("Sending workspace/didCreateFiles notification", params)
+function M.callback(data)
+  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
+    or vim.lsp.get_active_clients()
+  for _, client in pairs(clients) do
+    if client.initialized ~= nil and client.initialized then
+      local did_create = utils.get_nested_path(
+        client,
+        { "server_capabilities", "workspace", "fileOperations", "didCreate" }
+      )
+      if did_create then
+        local filters = did_create.filters or {}
+        if utils.matches_filters(filters, data.fname) then
+          local params = {
+            files = {
+              { uri = vim.uri_from_fname(data.fname) },
+            },
+          }
+          if vim.fn.has("nvim-0.11") == 1 then
+            client:notify("workspace/didCreateFiles", params)
+          else
+            client.notify("workspace/didCreateFiles", params)
+          end
+          log.debug("Sending workspace/didCreateFiles notification", params)
+        end
       end
     end
   end

--- a/lua/lsp-file-operations/did-create.lua
+++ b/lua/lsp-file-operations/did-create.lua
@@ -7,8 +7,7 @@ local M = {}
 function M.callback(data)
   utils.validate({ data = { data, { "table" } } })
 
-  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
-    or vim.lsp.get_active_clients()
+  local clients = utils.get_clients()
   for _, client in pairs(clients) do
     if client.initialized ~= nil and client.initialized then
       local did_create = utils.get_nested_path(
@@ -17,11 +16,7 @@ function M.callback(data)
       )
       if did_create and utils.matches_filters(did_create.filters or {}, data.fname) then
         local params = { files = { { uri = vim.uri_from_fname(data.fname) } } }
-        if vim.fn.has("nvim-0.11") == 1 then
-          client:notify("workspace/didCreateFiles", params)
-        else
-          client.notify("workspace/didCreateFiles", params)
-        end
+        utils.client_notify(client, "workspace/didCreateFiles", params)
         log.debug("Sending workspace/didCreateFiles notification", params)
       end
     end

--- a/lua/lsp-file-operations/did-create.lua
+++ b/lua/lsp-file-operations/did-create.lua
@@ -33,3 +33,4 @@ function M.callback(data)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations/did-delete.lua
+++ b/lua/lsp-file-operations/did-delete.lua
@@ -12,7 +12,7 @@ function M.callback(data)
         client,
         { "server_capabilities", "workspace", "fileOperations", "didDelete" }
       )
-      if did_delete ~= nil then
+      if did_delete then
         local filters = did_delete.filters or {}
         if utils.matches_filters(filters, data.fname) then
           local params = {

--- a/lua/lsp-file-operations/did-delete.lua
+++ b/lua/lsp-file-operations/did-delete.lua
@@ -7,8 +7,7 @@ local M = {}
 function M.callback(data)
   utils.validate({ data = { data, { "table" } } })
 
-  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
-    or vim.lsp.get_active_clients()
+  local clients = utils.get_clients()
   for _, client in pairs(clients) do
     if client.initialized ~= nil and client.initialized then
       local did_delete = utils.get_nested_path(
@@ -17,11 +16,7 @@ function M.callback(data)
       )
       if did_delete and utils.matches_filters(did_delete.filters or {}, data.fname) then
         local params = { files = { { uri = vim.uri_from_fname(data.fname) } } }
-        if vim.fn.has("nvim-0.11") == 1 then
-          client:notify("workspace/didDeleteFiles", params)
-        else
-          client.notify("workspace/didDeleteFiles", params)
-        end
+        utils.client_notify(client, "workspace/didDeleteFiles", params)
         log.debug("Sending workspace/didDeleteFiles notification", params)
       end
     end

--- a/lua/lsp-file-operations/did-delete.lua
+++ b/lua/lsp-file-operations/did-delete.lua
@@ -1,9 +1,12 @@
 local utils = require("lsp-file-operations.utils")
 local log = require("lsp-file-operations.log")
 
+---@class LspFileOps.DidDelete
 local M = {}
 
 function M.callback(data)
+  utils.validate({ data = { data, { "table" } } })
+
   local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
     or vim.lsp.get_active_clients()
   for _, client in pairs(clients) do
@@ -12,21 +15,14 @@ function M.callback(data)
         client,
         { "server_capabilities", "workspace", "fileOperations", "didDelete" }
       )
-      if did_delete then
-        local filters = did_delete.filters or {}
-        if utils.matches_filters(filters, data.fname) then
-          local params = {
-            files = {
-              { uri = vim.uri_from_fname(data.fname) },
-            },
-          }
-          if vim.fn.has("nvim-0.11") == 1 then
-            client:notify("workspace/didDeleteFiles", params)
-          else
-            client.notify("workspace/didDeleteFiles", params)
-          end
-          log.debug("Sending workspace/didDeleteFiles notification", params)
+      if did_delete and utils.matches_filters(did_delete.filters or {}, data.fname) then
+        local params = { files = { { uri = vim.uri_from_fname(data.fname) } } }
+        if vim.fn.has("nvim-0.11") == 1 then
+          client:notify("workspace/didDeleteFiles", params)
+        else
+          client.notify("workspace/didDeleteFiles", params)
         end
+        log.debug("Sending workspace/didDeleteFiles notification", params)
       end
     end
   end

--- a/lua/lsp-file-operations/did-delete.lua
+++ b/lua/lsp-file-operations/did-delete.lua
@@ -3,20 +3,30 @@ local log = require("lsp-file-operations.log")
 
 local M = {}
 
-M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
-    local did_delete =
-      utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "didDelete" })
-    if did_delete ~= nil then
-      local filters = did_delete.filters or {}
-      if utils.matches_filters(filters, data.fname) then
-        local params = {
-          files = {
-            { uri = vim.uri_from_fname(data.fname) },
-          },
-        }
-        client.notify("workspace/didDeleteFiles", params)
-        log.debug("Sending workspace/didDeleteFiles notification", params)
+function M.callback(data)
+  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
+    or vim.lsp.get_active_clients()
+  for _, client in pairs(clients) do
+    if client.initialized ~= nil and client.initialized then
+      local did_delete = utils.get_nested_path(
+        client,
+        { "server_capabilities", "workspace", "fileOperations", "didDelete" }
+      )
+      if did_delete ~= nil then
+        local filters = did_delete.filters or {}
+        if utils.matches_filters(filters, data.fname) then
+          local params = {
+            files = {
+              { uri = vim.uri_from_fname(data.fname) },
+            },
+          }
+          if vim.fn.has("nvim-0.11") == 1 then
+            client:notify("workspace/didDeleteFiles", params)
+          else
+            client.notify("workspace/didDeleteFiles", params)
+          end
+          log.debug("Sending workspace/didDeleteFiles notification", params)
+        end
       end
     end
   end

--- a/lua/lsp-file-operations/did-delete.lua
+++ b/lua/lsp-file-operations/did-delete.lua
@@ -33,3 +33,4 @@ function M.callback(data)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations/did-rename.lua
+++ b/lua/lsp-file-operations/did-rename.lua
@@ -3,20 +3,33 @@ local log = require("lsp-file-operations.log")
 
 local M = {}
 
-M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
-    local did_rename =
-      utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "didRename" })
-    if did_rename ~= nil then
-      local filters = did_rename.filters or {}
-      if utils.matches_filters(filters, data.old_name) then
-        local params = {
-          files = {
-            { oldUri = vim.uri_from_fname(data.old_name), newUri = vim.uri_from_fname(data.new_name) },
-          },
-        }
-        client.notify("workspace/didRenameFiles", params)
-        log.debug("Sending workspace/didRenameFiles notification", params)
+function M.callback(data)
+  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
+    or vim.lsp.get_active_clients()
+  for _, client in pairs(clients) do
+    if client.initialized ~= nil and client.initialized then
+      local did_rename = utils.get_nested_path(
+        client,
+        { "server_capabilities", "workspace", "fileOperations", "didRename" }
+      )
+      if did_rename ~= nil then
+        local filters = did_rename.filters or {}
+        if utils.matches_filters(filters, data.old_name) then
+          local params = {
+            files = {
+              {
+                oldUri = vim.uri_from_fname(data.old_name),
+                newUri = vim.uri_from_fname(data.new_name),
+              },
+            },
+          }
+          if vim.fn.has("nvim-0.11") == 1 then
+            client:notify("workspace/didRenameFiles", params)
+          else
+            client.notify("workspace/didRenameFiles", params)
+          end
+          log.debug("Sending workspace/didRenameFiles notification", params)
+        end
       end
     end
   end

--- a/lua/lsp-file-operations/did-rename.lua
+++ b/lua/lsp-file-operations/did-rename.lua
@@ -36,3 +36,4 @@ function M.callback(data)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations/did-rename.lua
+++ b/lua/lsp-file-operations/did-rename.lua
@@ -12,7 +12,7 @@ function M.callback(data)
         client,
         { "server_capabilities", "workspace", "fileOperations", "didRename" }
       )
-      if did_rename ~= nil then
+      if did_rename then
         local filters = did_rename.filters or {}
         if utils.matches_filters(filters, data.old_name) then
           local params = {

--- a/lua/lsp-file-operations/did-rename.lua
+++ b/lua/lsp-file-operations/did-rename.lua
@@ -1,3 +1,5 @@
+local uri = vim.uri_from_fname
+
 local utils = require("lsp-file-operations.utils")
 local log = require("lsp-file-operations.log")
 
@@ -7,8 +9,7 @@ local M = {}
 function M.callback(data)
   utils.validate({ data = { data, { "table" } } })
 
-  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
-    or vim.lsp.get_active_clients()
+  local clients = utils.get_clients()
   for _, client in pairs(clients) do
     if client.initialized ~= nil and client.initialized then
       local did_rename = utils.get_nested_path(
@@ -16,19 +17,8 @@ function M.callback(data)
         { "server_capabilities", "workspace", "fileOperations", "didRename" }
       )
       if did_rename and utils.matches_filters(did_rename.filters or {}, data.old_name) then
-        local params = {
-          files = {
-            {
-              oldUri = vim.uri_from_fname(data.old_name),
-              newUri = vim.uri_from_fname(data.new_name),
-            },
-          },
-        }
-        if vim.fn.has("nvim-0.11") == 1 then
-          client:notify("workspace/didRenameFiles", params)
-        else
-          client.notify("workspace/didRenameFiles", params)
-        end
+        local params = { files = { { oldUri = uri(data.old_name), newUri = uri(data.new_name) } } }
+        utils.client_notify(client, "workspace/didRenameFiles", params)
         log.debug("Sending workspace/didRenameFiles notification", params)
       end
     end

--- a/lua/lsp-file-operations/did-rename.lua
+++ b/lua/lsp-file-operations/did-rename.lua
@@ -1,9 +1,12 @@
 local utils = require("lsp-file-operations.utils")
 local log = require("lsp-file-operations.log")
 
+---@class LspFileOps.DidRename
 local M = {}
 
 function M.callback(data)
+  utils.validate({ data = { data, { "table" } } })
+
   local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
     or vim.lsp.get_active_clients()
   for _, client in pairs(clients) do
@@ -12,24 +15,21 @@ function M.callback(data)
         client,
         { "server_capabilities", "workspace", "fileOperations", "didRename" }
       )
-      if did_rename then
-        local filters = did_rename.filters or {}
-        if utils.matches_filters(filters, data.old_name) then
-          local params = {
-            files = {
-              {
-                oldUri = vim.uri_from_fname(data.old_name),
-                newUri = vim.uri_from_fname(data.new_name),
-              },
+      if did_rename and utils.matches_filters(did_rename.filters or {}, data.old_name) then
+        local params = {
+          files = {
+            {
+              oldUri = vim.uri_from_fname(data.old_name),
+              newUri = vim.uri_from_fname(data.new_name),
             },
-          }
-          if vim.fn.has("nvim-0.11") == 1 then
-            client:notify("workspace/didRenameFiles", params)
-          else
-            client.notify("workspace/didRenameFiles", params)
-          end
-          log.debug("Sending workspace/didRenameFiles notification", params)
+          },
+        }
+        if vim.fn.has("nvim-0.11") == 1 then
+          client:notify("workspace/didRenameFiles", params)
+        else
+          client.notify("workspace/didRenameFiles", params)
         end
+        log.debug("Sending workspace/didRenameFiles notification", params)
       end
     end
   end

--- a/lua/lsp-file-operations/log.lua
+++ b/lua/lsp-file-operations/log.lua
@@ -3,4 +3,3 @@ local log = require("plenary.log")
 return log.new({
   plugin = "nvim-lsp-file-operations",
 }, false)
-

--- a/lua/lsp-file-operations/log.lua
+++ b/lua/lsp-file-operations/log.lua
@@ -3,3 +3,4 @@ local log = require("plenary.log")
 return log.new({
   plugin = "nvim-lsp-file-operations",
 }, false)
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -1,16 +1,64 @@
+---Non-legacy validation spec (>=v0.11)
+---@class ValidateSpec
+---@field [1] any
+---@field [2] vim.validate.Validator
+---@field [3]? boolean
+---@field [4]? string
+
 local Path = require("plenary").path
 
 local log = require("lsp-file-operations.log")
 
+---@class LspFileOps.Utils
 local M = {}
+
+---Dynamic `vim.validate()` wrapper. Covers both legacy and newer implementations
+---@param T table<string, vim.validate.Spec|ValidateSpec>
+function M.validate(T)
+  if vim.fn.has("nvim-0.11") ~= 1 then
+    ---Filter table to fit legacy standard
+    ---@cast T table<string, vim.validate.Spec>
+    for name, spec in pairs(T) do
+      while #spec > 3 do
+        spec[#spec] = nil
+      end
+
+      T[name] = spec
+    end
+
+    vim.validate(T)
+    return
+  end
+
+  ---Filter table to fit non-legacy standard
+  ---@cast T table<string, ValidateSpec>
+  for name, spec in pairs(T) do
+    while #spec > 4 do
+      spec[#spec] = nil
+    end
+
+    T[name] = spec
+  end
+
+  for name, spec in pairs(T) do
+    table.insert(spec, 1, name)
+    vim.validate(unpack(spec))
+  end
+end
 
 ---@param T table
 ---@param keys (string|integer)[]
 ---@return table|nil
 function M.get_nested_path(T, keys)
-  if #keys == 0 then
+  M.validate({
+    T = { T, { "table" } },
+    keys = { keys, { "table" } },
+  })
+
+  if vim.tbl_sempty(keys) then
     return T
   end
+
   local key = keys[1]
   if T[key] == nil then
     return
@@ -23,6 +71,11 @@ end
 ---@param is_dir boolean
 ---@return string path
 local function ensure_dir_trailing_slash(path, is_dir)
+  M.validate({
+    path = { path, { "string" } },
+    is_dir = { is_dir, { "boolean" } },
+  })
+
   return (is_dir and not path:match("/$")) and (path .. "/") or path
 end
 
@@ -30,6 +83,8 @@ end
 ---@return string absolute_path
 ---@return boolean is_dir
 local function get_absolute_path(name)
+  M.validate({ name = { name, { "string" } } })
+
   local path = Path:new(name)
   local is_dir = path:is_dir()
   local absolute_path = ensure_dir_trailing_slash(path:absolute(), is_dir)
@@ -39,6 +94,8 @@ end
 ---@param pattern lsp.FileOperationPattern
 ---@return string regex
 local function get_regex(pattern)
+  M.validate({ pattern = { pattern, { "table" } } })
+
   local regex = vim.fn.glob2regpat(pattern.glob)
   return (pattern.options and pattern.options.ignoreCase) and ("\\c" .. regex) or regex
 end
@@ -48,6 +105,12 @@ end
 ---@param name string
 ---@param is_dir boolean
 local function match_filter(filter, name, is_dir)
+  M.validate({
+    filter = { filter, { "table" } },
+    name = { name, { "string" } },
+    is_dir = { is_dir, { "boolean" } },
+  })
+
   local match_type = filter.pattern.matches
   if
     not match_type
@@ -70,6 +133,11 @@ end
 ---@param filters lsp.FileOperationFilter[]
 ---@param name string
 function M.matches_filters(filters, name)
+  M.validate({
+    filters = { filters, { "table" } },
+    name = { name, { "string" } },
+  })
+
   local absolute_path, is_dir = get_absolute_path(name)
   for _, filter in pairs(filters) do
     if match_filter(filter, absolute_path, is_dir) then

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -1,49 +1,39 @@
 ---Non-legacy validation spec (>=v0.11)
----@class ValidateSpec
+---@class LspFileOps.ValidateSpec
 ---@field [1] any
 ---@field [2] vim.validate.Validator
 ---@field [3]? boolean
 ---@field [4]? string
 
 local Path = require("plenary").path
-
 local log = require("lsp-file-operations.log")
 
 ---@class LspFileOps.Utils
 local M = {}
 
----Dynamic `vim.validate()` wrapper. Covers both legacy and newer implementations
----@param T table<string, vim.validate.Spec|ValidateSpec>
+---Dynamic `vim.validate()` wrapper. Covers both legacy and newer implementations.
+--- ---
+---@param T table<string, vim.validate.Spec|LspFileOps.ValidateSpec>
 function M.validate(T)
-  if vim.fn.has("nvim-0.11") ~= 1 then
-    ---Filter table to fit legacy standard
-    ---@cast T table<string, vim.validate.Spec>
-    for name, spec in pairs(T) do
-      while #spec > 3 do
-        table.remove(spec, #spec)
-      end
-
-      T[name] = spec
-    end
-
-    vim.validate(T)
-    return
-  end
-
-  ---Filter table to fit non-legacy standard
-  ---@cast T table<string, ValidateSpec>
+  local max = vim.fn.has("nvim-0.11") == 1 and 3 or 4
   for name, spec in pairs(T) do
-    while #spec > 4 do
+    while #spec > max do
       table.remove(spec, #spec)
     end
-
     T[name] = spec
   end
 
-  for name, spec in pairs(T) do
-    table.insert(spec, 1, name)
-    vim.validate(unpack(spec))
+  if max == 3 then
+    ---@cast T LspFileOps.ValidateSpec
+    for name, spec in pairs(T) do
+      table.insert(spec, 1, name)
+      vim.validate(unpack(spec))
+    end
+    return
   end
+
+  ---@cast T vim.validate.Spec
+  vim.validate(T)
 end
 
 ---@return vim.lsp.Client[] clients

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -46,6 +46,30 @@ function M.validate(T)
   end
 end
 
+---@return vim.lsp.Client[] clients
+function M.get_clients()
+  ---@diagnostic disable-next-line:deprecated
+  return vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients() or vim.lsp.get_active_clients()
+end
+
+---@param client vim.lsp.Client
+---@param method vim.lsp.protocol.Method
+---@param params? table
+function M.client_notify(client, method, params)
+  M.validate({
+    client = { client, { "table" } },
+    method = { method, { "string" } },
+    params = { params, { "table", "nil" }, true },
+  })
+
+  if vim.fn.has("nvim-0.11") == 1 then
+    client:notify(method, params)
+    return
+  end
+
+  client.notify(method, params) ---@diagnostic disable-line:param-type-mismatch
+end
+
 ---@param T table
 ---@param keys (string|integer)[]
 ---@return table|nil

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -4,25 +4,31 @@ local log = require("lsp-file-operations.log")
 
 local M = {}
 
-function M.get_nested_path(table, keys)
+---@param T table
+---@param keys (string|integer)[]
+---@return table|nil
+function M.get_nested_path(T, keys)
   if #keys == 0 then
-    return table
+    return T
   end
   local key = keys[1]
-  if table[key] == nil then
+  if T[key] == nil then
     return
   end
-  return M.get_nested_path(table[key], { unpack(keys, 2) })
+  return M.get_nested_path(T[key], { unpack(keys, 2) })
 end
 
 -- needed for globs like `**/`
+---@param path string
+---@param is_dir boolean
+---@return string path
 local function ensure_dir_trailing_slash(path, is_dir)
-  if is_dir and not path:match("/$") then
-    return path .. "/"
-  end
-  return path
+  return (is_dir and not path:match("/$")) and (path .. "/") or path
 end
 
+---@param name string
+---@return string absolute_path
+---@return boolean is_dir
 local function get_absolute_path(name)
   local path = Path:new(name)
   local is_dir = path:is_dir()
@@ -30,24 +36,25 @@ local function get_absolute_path(name)
   return absolute_path, is_dir
 end
 
+---@param pattern lsp.FileOperationPattern
+---@return string regex
 local function get_regex(pattern)
   local regex = vim.fn.glob2regpat(pattern.glob)
-  if pattern.options and pattern.options.ignorecase then
-    return "\\c" .. regex
-  end
-  return regex
+  return (pattern.options and pattern.options.ignoreCase) and ("\\c" .. regex) or regex
 end
 
 -- filter: FileOperationFilter
+---@param filter lsp.FileOperationFilter
+---@param name string
+---@param is_dir boolean
 local function match_filter(filter, name, is_dir)
-  local pattern = filter.pattern
-  local match_type = pattern.matches
+  local match_type = filter.pattern.matches
   if
     not match_type
     or (match_type == "folder" and is_dir)
     or (match_type == "file" and not is_dir)
   then
-    local regex = get_regex(pattern)
+    local regex = get_regex(filter.pattern)
     log.debug("Matching name", name, "to pattern", regex)
     local previous_ignorecase = vim.o.ignorecase
     vim.o.ignorecase = false
@@ -60,6 +67,8 @@ local function match_filter(filter, name, is_dir)
 end
 
 -- filters: FileOperationFilter[]
+---@param filters lsp.FileOperationFilter[]
+---@param name string
 function M.matches_filters(filters, name)
   local absolute_path, is_dir = get_absolute_path(name)
   for _, filter in pairs(filters) do

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -55,7 +55,7 @@ function M.get_nested_path(T, keys)
     keys = { keys, { "table" } },
   })
 
-  if vim.tbl_sempty(keys) then
+  if vim.tbl_isempty(keys) then
     return T
   end
 

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -82,3 +82,4 @@ function M.matches_filters(filters, name)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -4,47 +4,48 @@ local log = require("lsp-file-operations.log")
 
 local M = {}
 
-M.get_nested_path = function(table, keys)
+function M.get_nested_path(table, keys)
   if #keys == 0 then
     return table
   end
   local key = keys[1]
   if table[key] == nil then
-    return nil
+    return
   end
   return M.get_nested_path(table[key], { unpack(keys, 2) })
 end
 
 -- needed for globs like `**/`
-local ensure_dir_trailing_slash = function(path, is_dir)
+local function ensure_dir_trailing_slash(path, is_dir)
   if is_dir and not path:match("/$") then
-    return path .. '/'
+    return path .. "/"
   end
   return path
 end
 
-local get_absolute_path = function(name)
+local function get_absolute_path(name)
   local path = Path:new(name)
   local is_dir = path:is_dir()
   local absolute_path = ensure_dir_trailing_slash(path:absolute(), is_dir)
   return absolute_path, is_dir
 end
 
-local get_regex = function (pattern)
-    local regex = vim.fn.glob2regpat(pattern.glob)
-    if pattern.options and pattern.options.ignorecase then
-      return "\\c" .. regex
-    end
-    return regex
+local function get_regex(pattern)
+  local regex = vim.fn.glob2regpat(pattern.glob)
+  if pattern.options and pattern.options.ignorecase then
+    return "\\c" .. regex
+  end
+  return regex
 end
 
 -- filter: FileOperationFilter
-local match_filter = function(filter, name, is_dir)
+local function match_filter(filter, name, is_dir)
   local pattern = filter.pattern
   local match_type = pattern.matches
-  if not match_type or
-      (match_type == "folder" and is_dir) or
-      (match_type == "file" and not is_dir)
+  if
+    not match_type
+    or (match_type == "folder" and is_dir)
+    or (match_type == "file" and not is_dir)
   then
     local regex = get_regex(pattern)
     log.debug("Matching name", name, "to pattern", regex)
@@ -59,7 +60,7 @@ local match_filter = function(filter, name, is_dir)
 end
 
 -- filters: FileOperationFilter[]
-M.matches_filters = function(filters, name)
+function M.matches_filters(filters, name)
   local absolute_path, is_dir = get_absolute_path(name)
   for _, filter in pairs(filters) do
     if match_filter(filter, absolute_path, is_dir) then

--- a/lua/lsp-file-operations/utils.lua
+++ b/lua/lsp-file-operations/utils.lua
@@ -20,7 +20,7 @@ function M.validate(T)
     ---@cast T table<string, vim.validate.Spec>
     for name, spec in pairs(T) do
       while #spec > 3 do
-        spec[#spec] = nil
+        table.remove(spec, #spec)
       end
 
       T[name] = spec
@@ -34,7 +34,7 @@ function M.validate(T)
   ---@cast T table<string, ValidateSpec>
   for name, spec in pairs(T) do
     while #spec > 4 do
-      spec[#spec] = nil
+      table.remove(spec, #spec)
     end
 
     T[name] = spec

--- a/lua/lsp-file-operations/will-create.lua
+++ b/lua/lsp-file-operations/will-create.lua
@@ -13,30 +13,37 @@ local function getWorkspaceEdit(client, fname)
   }
   log.debug("Sending workspace/willCreateFiles request", will_create_params)
   local timeout_ms = require("lsp-file-operations").config.timeout_ms
-  local success, resp = pcall(client.request_sync, "workspace/willCreateFiles", will_create_params, timeout_ms)
+  local success, resp =
+    pcall(client.request_sync, "workspace/willCreateFiles", will_create_params, timeout_ms)
   log.debug("Got workspace/willCreateFiles response", resp)
   if not success then
     log.error("Error while sending workspace/willCreateFiles request", resp)
-    return nil
+    return
   end
-  if resp == nil or resp.result == nil then
+  if not (resp and resp.result) then
     log.warn("Got empty workspace/willCreateFiles response, maybe a timeout?")
-    return nil
+    return
   end
   return resp.result
 end
 
-M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
-    local will_create =
-      utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "willCreate" })
-    if will_create ~= nil then
-      local filters = will_create.filters or {}
-      if utils.matches_filters(filters, data.fname) then
-        local edit = getWorkspaceEdit(client, data.fname)
-        if edit ~= nil then
-          log.debug("Going to apply workspace/willCreateFiles edit", edit)
-          vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
+function M.callback(data)
+  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
+    or vim.lsp.get_active_clients()
+  for _, client in pairs(clients) do
+    if client.initialized ~= nil and client.initialized then
+      local will_create = utils.get_nested_path(
+        client,
+        { "server_capabilities", "workspace", "fileOperations", "willCreate" }
+      )
+      if will_create ~= nil then
+        local filters = will_create.filters or {}
+        if utils.matches_filters(filters, data.fname) then
+          local edit = getWorkspaceEdit(client, data.fname)
+          if edit ~= nil then
+            log.debug("Going to apply workspace/willCreateFiles edit", edit)
+            vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
+          end
         end
       end
     end

--- a/lua/lsp-file-operations/will-create.lua
+++ b/lua/lsp-file-operations/will-create.lua
@@ -45,3 +45,4 @@ function M.callback(data)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations/will-create.lua
+++ b/lua/lsp-file-operations/will-create.lua
@@ -33,8 +33,7 @@ end
 function M.callback(data)
   utils.validate({ data = { data, { "table" } } })
 
-  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
-    or vim.lsp.get_active_clients()
+  local clients = utils.get_clients()
   for _, client in pairs(clients) do
     if client.initialized ~= nil and client.initialized then
       local will_create = utils.get_nested_path(

--- a/lua/lsp-file-operations/will-create.lua
+++ b/lua/lsp-file-operations/will-create.lua
@@ -1,12 +1,18 @@
 local utils = require("lsp-file-operations.utils")
 local log = require("lsp-file-operations.log")
 
+---@class LspFileOps.WillCreate
 local M = {}
 
 ---@param client vim.lsp.Client
 ---@param fname string
 ---@return lsp.WorkspaceEdit|nil
 local function getWorkspaceEdit(client, fname)
+  utils.validate({
+    client = { client, { "table" } },
+    fname = { fname, { "string" } },
+  })
+
   local will_create_params = { files = { { uri = vim.uri_from_fname(fname) } } }
   log.debug("Sending workspace/willCreateFiles request", will_create_params)
   local timeout_ms = require("lsp-file-operations").config.timeout_ms
@@ -25,6 +31,8 @@ local function getWorkspaceEdit(client, fname)
 end
 
 function M.callback(data)
+  utils.validate({ data = { data, { "table" } } })
+
   local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
     or vim.lsp.get_active_clients()
   for _, client in pairs(clients) do

--- a/lua/lsp-file-operations/will-create.lua
+++ b/lua/lsp-file-operations/will-create.lua
@@ -3,14 +3,11 @@ local log = require("lsp-file-operations.log")
 
 local M = {}
 
+---@param client vim.lsp.Client
+---@param fname string
+---@return lsp.WorkspaceEdit|nil
 local function getWorkspaceEdit(client, fname)
-  local will_create_params = {
-    files = {
-      {
-        uri = vim.uri_from_fname(fname),
-      },
-    },
-  }
+  local will_create_params = { files = { { uri = vim.uri_from_fname(fname) } } }
   log.debug("Sending workspace/willCreateFiles request", will_create_params)
   local timeout_ms = require("lsp-file-operations").config.timeout_ms
   local success, resp =
@@ -36,14 +33,11 @@ function M.callback(data)
         client,
         { "server_capabilities", "workspace", "fileOperations", "willCreate" }
       )
-      if will_create ~= nil then
-        local filters = will_create.filters or {}
-        if utils.matches_filters(filters, data.fname) then
-          local edit = getWorkspaceEdit(client, data.fname)
-          if edit ~= nil then
-            log.debug("Going to apply workspace/willCreateFiles edit", edit)
-            vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
-          end
+      if will_create and utils.matches_filters(will_create.filters or {}, data.fname) then
+        local edit = getWorkspaceEdit(client, data.fname)
+        if edit then
+          log.debug("Going to apply workspace/willCreateFiles edit", edit)
+          vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
         end
       end
     end

--- a/lua/lsp-file-operations/will-delete.lua
+++ b/lua/lsp-file-operations/will-delete.lua
@@ -1,19 +1,14 @@
 local utils = require("lsp-file-operations.utils")
 local log = require("lsp-file-operations.log")
 
+---@class LspFileOps.WillDelete
 local M = {}
 
 ---@param client vim.lsp.Client
 ---@param fname string
 ---@return lsp.WorkspaceEdit|nil
 local function getWorkspaceEdit(client, fname)
-  local will_delete_params = {
-    files = {
-      {
-        uri = vim.uri_from_fname(fname),
-      },
-    },
-  }
+  local will_delete_params = { files = { { uri = vim.uri_from_fname(fname) } } }
   log.debug("Sending workspace/willDeleteFiles request", will_delete_params)
   local timeout_ms = require("lsp-file-operations").config.timeout_ms
   local success, resp =
@@ -31,6 +26,8 @@ local function getWorkspaceEdit(client, fname)
 end
 
 function M.callback(data)
+  utils.validate({ data = { data, { "table" } } })
+
   local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
     or vim.lsp.get_active_clients()
   for _, client in pairs(clients) do

--- a/lua/lsp-file-operations/will-delete.lua
+++ b/lua/lsp-file-operations/will-delete.lua
@@ -51,3 +51,4 @@ function M.callback(data)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations/will-delete.lua
+++ b/lua/lsp-file-operations/will-delete.lua
@@ -3,6 +3,9 @@ local log = require("lsp-file-operations.log")
 
 local M = {}
 
+---@param client vim.lsp.Client
+---@param fname string
+---@return lsp.WorkspaceEdit|nil
 local function getWorkspaceEdit(client, fname)
   local will_delete_params = {
     files = {
@@ -36,14 +39,11 @@ function M.callback(data)
         client,
         { "server_capabilities", "workspace", "fileOperations", "willDelete" }
       )
-      if will_delete ~= nil then
-        local filters = will_delete.filters or {}
-        if utils.matches_filters(filters, data.fname) then
-          local edit = getWorkspaceEdit(client, data.fname)
-          if edit ~= nil then
-            log.debug("Going to apply workspace/willDelete edit", edit)
-            vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
-          end
+      if will_delete and utils.matches_filters(will_delete.filters or {}, data.fname) then
+        local edit = getWorkspaceEdit(client, data.fname)
+        if edit then
+          log.debug("Going to apply workspace/willDelete edit", edit)
+          vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
         end
       end
     end

--- a/lua/lsp-file-operations/will-delete.lua
+++ b/lua/lsp-file-operations/will-delete.lua
@@ -13,30 +13,37 @@ local function getWorkspaceEdit(client, fname)
   }
   log.debug("Sending workspace/willDeleteFiles request", will_delete_params)
   local timeout_ms = require("lsp-file-operations").config.timeout_ms
-  local success, resp = pcall(client.request_sync, "workspace/willDeleteFiles", will_delete_params, timeout_ms)
+  local success, resp =
+    pcall(client.request_sync, "workspace/willDeleteFiles", will_delete_params, timeout_ms)
   log.debug("Got workspace/willDeleteFiles response", resp)
   if not success then
     log.error("Error while sending workspace/willDeleteFiles request", resp)
-    return nil
+    return
   end
-  if resp == nil or resp.result == nil then
+  if not (resp and resp.result) then
     log.warn("Got empty workspace/willDeleteFiles response, maybe a timeout?")
-    return nil
+    return
   end
   return resp.result
 end
 
-M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
-    local will_delete =
-      utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "willDelete" })
-    if will_delete ~= nil then
-      local filters = will_delete.filters or {}
-      if utils.matches_filters(filters, data.fname) then
-        local edit = getWorkspaceEdit(client, data.fname)
-        if edit ~= nil then
-          log.debug("Going to apply workspace/willDelete edit", edit)
-          vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
+function M.callback(data)
+  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
+    or vim.lsp.get_active_clients()
+  for _, client in pairs(clients) do
+    if client.initialized ~= nil and client.initialized then
+      local will_delete = utils.get_nested_path(
+        client,
+        { "server_capabilities", "workspace", "fileOperations", "willDelete" }
+      )
+      if will_delete ~= nil then
+        local filters = will_delete.filters or {}
+        if utils.matches_filters(filters, data.fname) then
+          local edit = getWorkspaceEdit(client, data.fname)
+          if edit ~= nil then
+            log.debug("Going to apply workspace/willDelete edit", edit)
+            vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
+          end
         end
       end
     end

--- a/lua/lsp-file-operations/will-delete.lua
+++ b/lua/lsp-file-operations/will-delete.lua
@@ -28,8 +28,7 @@ end
 function M.callback(data)
   utils.validate({ data = { data, { "table" } } })
 
-  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
-    or vim.lsp.get_active_clients()
+  local clients = utils.get_clients()
   for _, client in pairs(clients) do
     if client.initialized ~= nil and client.initialized then
       local will_delete = utils.get_nested_path(

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -37,8 +37,7 @@ end
 function M.callback(data)
   utils.validate({ data = { data, { "table" } } })
 
-  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
-    or vim.lsp.get_active_clients()
+  local clients = utils.get_clients()
   for _, client in pairs(clients) do
     if client.initialized ~= nil and client.initialized then
       local will_rename = utils.get_nested_path(

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -14,30 +14,37 @@ local function getWorkspaceEdit(client, old_name, new_name)
   }
   log.debug("Sending workspace/willRenameFiles request", will_rename_params)
   local timeout_ms = require("lsp-file-operations").config.timeout_ms
-  local success, resp = pcall(client.request_sync, "workspace/willRenameFiles", will_rename_params, timeout_ms)
+  local success, resp =
+    pcall(client.request_sync, "workspace/willRenameFiles", will_rename_params, timeout_ms)
   log.debug("Got workspace/willRenameFiles response", resp)
   if not success then
     log.error("Error while sending workspace/willRenameFiles request", resp)
-    return nil
+    return
   end
-  if resp == nil or resp.result == nil then
+  if not (resp and resp.result) then
     log.warn("Got empty workspace/willRenameFiles response, maybe a timeout?")
-    return nil
+    return
   end
   return resp.result
 end
 
-M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
-    local will_rename =
-      utils.get_nested_path(client, { "server_capabilities", "workspace", "fileOperations", "willRename" })
-    if will_rename ~= nil then
-      local filters = will_rename.filters or {}
-      if utils.matches_filters(filters, data.old_name) then
-        local edit = getWorkspaceEdit(client, data.old_name, data.new_name)
-        if edit ~= nil then
-          log.debug("Going to apply workspace/willRename edit", edit)
-          vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
+function M.callback(data)
+  local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
+    or vim.lsp.get_active_clients()
+  for _, client in pairs(clients) do
+    if client.initialized ~= nil and client.initialized then
+      local will_rename = utils.get_nested_path(
+        client,
+        { "server_capabilities", "workspace", "fileOperations", "willRename" }
+      )
+      if will_rename ~= nil then
+        local filters = will_rename.filters or {}
+        if utils.matches_filters(filters, data.old_name) then
+          local edit = getWorkspaceEdit(client, data.old_name, data.new_name)
+          if edit ~= nil then
+            log.debug("Going to apply workspace/willRename edit", edit)
+            vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
+          end
         end
       end
     end

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -53,3 +53,4 @@ function M.callback(data)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -1,6 +1,7 @@
 local utils = require("lsp-file-operations.utils")
 local log = require("lsp-file-operations.log")
 
+---@class LspFileOps.WillRename
 local M = {}
 
 ---@param client vim.lsp.Client
@@ -8,13 +9,14 @@ local M = {}
 ---@param new_name string
 ---@return lsp.WorkspaceEdit|nil
 local function getWorkspaceEdit(client, old_name, new_name)
+  utils.validate({
+    client = { client, { "table" } },
+    old_name = { old_name, { "string" } },
+    new_name = { new_name, { "string" } },
+  })
+
   local will_rename_params = {
-    files = {
-      {
-        oldUri = vim.uri_from_fname(old_name),
-        newUri = vim.uri_from_fname(new_name),
-      },
-    },
+    files = { { oldUri = vim.uri_from_fname(old_name), newUri = vim.uri_from_fname(new_name) } },
   }
   log.debug("Sending workspace/willRenameFiles request", will_rename_params)
   local timeout_ms = require("lsp-file-operations").config.timeout_ms
@@ -33,6 +35,8 @@ local function getWorkspaceEdit(client, old_name, new_name)
 end
 
 function M.callback(data)
+  utils.validate({ data = { data, { "table" } } })
+
   local clients = vim.fn.has("nvim-0.10") == 1 and vim.lsp.get_clients()
     or vim.lsp.get_active_clients()
   for _, client in pairs(clients) do

--- a/lua/lsp-file-operations/will-rename.lua
+++ b/lua/lsp-file-operations/will-rename.lua
@@ -3,6 +3,10 @@ local log = require("lsp-file-operations.log")
 
 local M = {}
 
+---@param client vim.lsp.Client
+---@param old_name string
+---@param new_name string
+---@return lsp.WorkspaceEdit|nil
 local function getWorkspaceEdit(client, old_name, new_name)
   local will_rename_params = {
     files = {
@@ -37,14 +41,11 @@ function M.callback(data)
         client,
         { "server_capabilities", "workspace", "fileOperations", "willRename" }
       )
-      if will_rename ~= nil then
-        local filters = will_rename.filters or {}
-        if utils.matches_filters(filters, data.old_name) then
-          local edit = getWorkspaceEdit(client, data.old_name, data.new_name)
-          if edit ~= nil then
-            log.debug("Going to apply workspace/willRename edit", edit)
-            vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
-          end
+      if will_rename and utils.matches_filters(will_rename.filters or {}, data.old_name) then
+        local edit = getWorkspaceEdit(client, data.old_name, data.new_name)
+        if edit then
+          log.debug("Going to apply workspace/willRename edit", edit)
+          vim.lsp.util.apply_workspace_edit(edit, client.offset_encoding)
         end
       end
     end

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,12 @@
+call_parentheses = "Always"
+collapse_simple_statement = "Never"
+column_width = 100
+indent_type = "Spaces"
+indent_width = 2
+line_endings = "Unix"
+quote_style = "AutoPreferDouble"
+space_after_function_names = "Never"
+syntax = 'LuaJIT'
+
+[sort_requires]
+enabled = false

--- a/stylua.toml
+++ b/stylua.toml
@@ -10,3 +10,4 @@ syntax = 'LuaJIT'
 
 [sort_requires]
 enabled = false
+# vim: set ts=4 sts=4 sw=4 et ai si sta:


### PR DESCRIPTION
Fixes #31

## Changes

- Fixed `vim.lsp` deprecations without dropping legacy versions
- Fixed `client.notify` deprecation without dropping legacy versions
- Consistent use of `function X()` instead of `X = function()` if possible
- StyLua formatting for consistent styling (indentation was respected)

Sorry I couldn't separate these changes. Because of a 2-space indentation style I had to adjust my editor.
